### PR TITLE
Fix bugs, add PrettyPrint examples, add UTF-8/Binary alternative encodings.  

### DIFF
--- a/prettyprint_test.go
+++ b/prettyprint_test.go
@@ -1,0 +1,52 @@
+package sequitur
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const peasePudding = `
+pease porridge hot,
+pease porridge cold,
+pease porridge in the pot,
+nine days old.
+
+some like it hot,
+some like it cold,
+some like it in the pot,
+nine days old.
+`
+
+func ExamplePrettyPrint() {
+
+	g := new(Grammar)
+
+	err := g.Parse([]byte(peasePudding))
+	if err != nil {
+		panic(err)
+	}
+
+	var output bytes.Buffer
+	err = g.PrettyPrint(&output)
+	if err != nil {
+		panic(err)
+	}
+
+	// this next line just required to make the output correct for the test to pass
+	fmt.Println(string(bytes.Replace(output.Bytes(), []byte(" \n"), []byte("\n"), -1)))
+
+	// Output:
+	// 0 -> 1 2 3 4 3 5 \n 6 2 7 4 7 5
+	// 1 -> \n p e a s 8 r r i d g 9
+	// 2 -> h o t
+	// 3 -> , 1
+	// 4 -> c 10
+	// 5 -> 11 _ t h 8 t 12 n 11 9 d a y s _ 10 . \n
+	// 6 -> s o m 9 l i k 9 i t _
+	// 7 -> 12 6
+	// 8 -> 9 p o
+	// 9 -> e _
+	// 10 -> o l d
+	// 11 -> i n
+	// 12 -> , \n
+}

--- a/prettyprint_test.go
+++ b/prettyprint_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const peasePudding = `
+const testString = `
 pease porridge hot,
 pease porridge cold,
 pease porridge in the pot,
@@ -15,13 +15,24 @@ some like it hot,
 some like it cold,
 some like it in the pot,
 nine days old.
-`
+
+《施氏食狮史》
+石室诗士施氏，嗜狮，誓食十狮。
+氏时时适市视狮。
+十时，适十狮适市。 
+是时，适施氏适市。氏视是十狮，恃矢势，使是十狮逝世。
+氏拾是十狮尸，适石室。
+石室湿，氏使侍拭石室。
+石室拭，氏始试食是十狮尸。
+食时，始识是十狮，实十石狮尸。
+试释是事。
+` // https://www.duolingo.com/comment/25323797/Fun-Chinese-poem-The-Lion-Eating-Poet-in-the-Stone-Den
 
 func ExamplePrettyPrint() {
 
 	g := new(Grammar)
 
-	err := g.Parse([]byte(peasePudding))
+	err := g.Parse([]byte(testString))
 	if err != nil {
 		panic(err)
 	}
@@ -36,17 +47,31 @@ func ExamplePrettyPrint() {
 	fmt.Println(string(bytes.Replace(output.Bytes(), []byte(" \n"), []byte("\n"), -1)))
 
 	// Output:
-	// 0 -> 1 2 3 4 3 5 \n 6 2 7 4 7 5
-	// 1 -> \n p e a s 8 r r i d g 9
+	// 0 -> 1 2 3 4 3 5 6 2 7 4 7 5 《 8 食 狮 史 》 \n 9 诗 士 8 ， 嗜 狮 ， 誓 食 十 10 氏 时 时 11 视 10 十 12 13 14 _ \n 是 12 8 14 氏 视 15 恃 矢 势 ， 使 16 逝 世 17 氏 拾 18 19 20 湿 21 使 侍 拭 20 拭 21 始 试 食 18 17 食 时 ， 始 识 15 实 十 石 狮 尸 17 试 释 是 事 17
+	// 1 -> \n p e a s 22 r r i d g 23
 	// 2 -> h o t
 	// 3 -> , 1
-	// 4 -> c 10
-	// 5 -> 11 _ t h 8 t 12 n 11 9 d a y s _ 10 . \n
-	// 6 -> s o m 9 l i k 9 i t _
-	// 7 -> 12 6
-	// 8 -> 9 p o
-	// 9 -> e _
-	// 10 -> o l d
-	// 11 -> i n
-	// 12 -> , \n
+	// 4 -> c 24
+	// 5 -> 25 _ t h 22 t 26 n 25 23 d a y s _ 24 . \n \n
+	// 6 -> s o m 23 l i k 23 i t _
+	// 7 -> 26 6
+	// 8 -> 施 氏
+	// 9 -> 石 室
+	// 10 -> 狮 17
+	// 11 -> 适 市
+	// 12 -> 时 19
+	// 13 -> 十 狮
+	// 14 -> 11 。
+	// 15 -> 16 ，
+	// 16 -> 是 13
+	// 17 -> 。 \n
+	// 18 -> 16 尸
+	// 19 -> ， 适
+	// 20 -> 9 17 9
+	// 21 -> ， 氏
+	// 22 -> 23 p o
+	// 23 -> e _
+	// 24 -> o l d
+	// 25 -> i n
+	// 26 -> , \n
 }

--- a/prettyprintbinary_test.go
+++ b/prettyprintbinary_test.go
@@ -9,9 +9,7 @@ var testBinary = []byte{0xfe, 0xff, 0xfd, 0xfe, 0xff, 1, 2, 3, 4, 5, 'a', 'b', 1
 
 func ExamplePrettyPrintBinary() {
 
-	g := new(Grammar)
-
-	err := g.ParseBinary(testBinary)
+	g, err := ParseBinary(testBinary)
 	if err != nil {
 		panic(err)
 	}

--- a/prettyprintbinary_test.go
+++ b/prettyprintbinary_test.go
@@ -1,0 +1,32 @@
+package sequitur
+
+import (
+	"bytes"
+	"fmt"
+)
+
+var testBinary = []byte{1, 2, 3, 4, 5, 'a', 'b', 5, 4, 3, 2, 1, 1, 'a', 'b', 2, 3, 4, 5, 2, 3}
+
+func ExamplePrettyPrintBinary() {
+
+	g := new(Grammar)
+
+	err := g.ParseBinary(testBinary)
+	if err != nil {
+		panic(err)
+	}
+
+	var output bytes.Buffer
+	err = g.PrettyPrint(&output)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(output.Bytes()))
+
+	// Output:
+	// 0 -> 0x01 1 2 0x05 0x04 0x03 0x02 0x01 0x01 2 1 3
+	// 1 -> 3 0x04 0x05
+	// 2 -> a b
+	// 3 -> 0x02 0x03
+}

--- a/prettyprintbinary_test.go
+++ b/prettyprintbinary_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-var testBinary = []byte{1, 2, 3, 4, 5, 'a', 'b', 5, 4, 3, 2, 1, 1, 'a', 'b', 2, 3, 4, 5, 2, 3}
+var testBinary = []byte{0xfe, 0xff, 0xfd, 0xfe, 0xff, 1, 2, 3, 4, 5, 'a', 'b', 1, 2, 3, 4, 5, 'a', 'b'}
 
 func ExamplePrettyPrintBinary() {
 
@@ -25,8 +25,7 @@ func ExamplePrettyPrintBinary() {
 	fmt.Println(string(output.Bytes()))
 
 	// Output:
-	// 0 -> 0x01 1 2 0x05 0x04 0x03 0x02 0x01 0x01 2 1 3
-	// 1 -> 3 0x04 0x05
-	// 2 -> a b
-	// 3 -> 0x02 0x03
+	// 0 -> 1 0xFD 1 2 2
+	// 1 -> 0xFE 0xFF
+	// 2 -> 0x01 0x02 0x03 0x04 0x05 a b
 }

--- a/prettyprintutf8_test.go
+++ b/prettyprintutf8_test.go
@@ -31,9 +31,7 @@ nine days old.
 
 func ExamplePrettyPrintUTF8() {
 
-	g := new(Grammar)
-
-	err := g.ParseUTF8([]byte(testString))
+	g, err := ParseUTF8([]byte(testString))
 	if err != nil {
 		panic(err)
 	}

--- a/prettyprintutf8_test.go
+++ b/prettyprintutf8_test.go
@@ -19,8 +19,9 @@ nine days old.
 《施氏食狮史》
 石室诗士施氏，嗜狮，誓食十狮。
 氏时时适市视狮。
-十时，适十狮适市。 
-是时，适施氏适市。氏视是十狮，恃矢势，使是十狮逝世。
+十时，适十狮适市。
+是时，适施氏适市。
+氏视是十狮，恃矢势，使是十狮逝世。
 氏拾是十狮尸，适石室。
 石室湿，氏使侍拭石室。
 石室拭，氏始试食是十狮尸。
@@ -28,11 +29,11 @@ nine days old.
 试释是事。
 ` // https://www.duolingo.com/comment/25323797/Fun-Chinese-poem-The-Lion-Eating-Poet-in-the-Stone-Den
 
-func ExamplePrettyPrint() {
+func ExamplePrettyPrintUTF8() {
 
 	g := new(Grammar)
 
-	err := g.Parse([]byte(testString))
+	err := g.ParseUTF8([]byte(testString))
 	if err != nil {
 		panic(err)
 	}
@@ -43,11 +44,10 @@ func ExamplePrettyPrint() {
 		panic(err)
 	}
 
-	// this next line just required to make the output correct for the test to pass
-	fmt.Println(string(bytes.Replace(output.Bytes(), []byte(" \n"), []byte("\n"), -1)))
+	fmt.Println(string(output.Bytes()))
 
 	// Output:
-	// 0 -> 1 2 3 4 3 5 6 2 7 4 7 5 《 8 食 狮 史 》 \n 9 诗 士 8 ， 嗜 狮 ， 誓 食 十 10 氏 时 时 11 视 10 十 12 13 14 _ \n 是 12 8 14 氏 视 15 恃 矢 势 ， 使 16 逝 世 17 氏 拾 18 19 20 湿 21 使 侍 拭 20 拭 21 始 试 食 18 17 食 时 ， 始 识 15 实 十 石 狮 尸 17 试 释 是 事 17
+	// 0 -> 1 2 3 4 3 5 6 2 7 4 7 5 《 8 食 狮 史 》 \n 9 诗 士 8 ， 嗜 狮 ， 誓 食 十 10 氏 时 时 11 视 10 十 12 13 14 是 12 8 14 氏 视 15 恃 矢 势 ， 使 16 逝 世 17 氏 拾 18 19 20 湿 21 使 侍 拭 20 拭 21 始 试 食 18 17 食 时 ， 始 识 15 实 十 石 狮 尸 17 试 释 是 事 17
 	// 1 -> \n p e a s 22 r r i d g 23
 	// 2 -> h o t
 	// 3 -> , 1
@@ -61,7 +61,7 @@ func ExamplePrettyPrint() {
 	// 11 -> 适 市
 	// 12 -> 时 19
 	// 13 -> 十 狮
-	// 14 -> 11 。
+	// 14 -> 11 17
 	// 15 -> 16 ，
 	// 16 -> 是 13
 	// 17 -> 。 \n

--- a/sequitur.go
+++ b/sequitur.go
@@ -323,10 +323,16 @@ func (g *Grammar) PrettyPrint(w io.Writer) error {
 // ErrAlreadyParsed is returned if the grammar instance has already parsed a grammar
 var ErrAlreadyParsed = errors.New("sequitor: grammar already parsed")
 
+// ErrEmptyInput is returned if the input string is empty
+var ErrEmptyInput = errors.New("sequitor: empty input")
+
 // Parse parses a byte string
 func (g *Grammar) Parse(str []byte) error {
 	if g.base != nil {
 		return ErrAlreadyParsed
+	}
+	if len(str) == 0 {
+		return ErrEmptyInput
 	}
 
 	g.ruleID = 256

--- a/sequitur.go
+++ b/sequitur.go
@@ -287,7 +287,12 @@ func rawPrint(w io.Writer, r *rules) error {
 			}
 		} else {
 			rb := make([]byte, utf8.UTFMax)
-			sz := utf8.EncodeRune(rb, rune(p.value))
+			sz := 1
+			if p.value <= 0xff {
+				rb[0] = byte(p.value)
+			} else {
+				sz = utf8.EncodeRune(rb, rune(p.value))
+			}
 			if _, err := w.Write(rb[:sz]); err != nil {
 				return err
 			}
@@ -339,13 +344,15 @@ var ErrEmptyInput = errors.New("sequitor: empty input")
 var ErrMalformedUTF8 = errors.New("sequitor: malformed utf-8 input")
 
 // ParseUTF8 parses a byte string using utf-8 encoding
-func (g *Grammar) ParseUTF8(str []byte) error {
-	return g.parse(str, true)
+func ParseUTF8(str []byte) (*Grammar, error) {
+	g := new(Grammar)
+	return g, g.parse(str, true)
 }
 
 // ParseBinary parses a binary byte string
-func (g *Grammar) ParseBinary(str []byte) error {
-	return g.parse(str, false)
+func ParseBinary(str []byte) (*Grammar, error) {
+	g := new(Grammar)
+	return g, g.parse(str, false)
 }
 
 func (g *Grammar) parse(str []byte, useUTF8 bool) error {

--- a/sequitur.go
+++ b/sequitur.go
@@ -263,7 +263,7 @@ func (pr *prettyPrinter) printTerminal(w io.Writer, sym uint64) error {
 		out = append(out, '\\', byte(sym))
 	default:
 		r := rune(sym)
-		if unicode.IsPrint(r) {
+		if unicode.IsPrint(r) && (r < utf8.RuneSelf || r > 0xff) {
 			out = append(out, make([]byte, utf8.UTFMax)...)
 			sz := utf8.EncodeRune(out[1:], r)
 			out = out[:1+sz]

--- a/sequitur_test.go
+++ b/sequitur_test.go
@@ -2,13 +2,14 @@ package sequitur
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 	"unicode/utf8"
 )
 
 func TestNoInput(t *testing.T) {
 	g := new(Grammar)
-	err := g.Parse([]byte{})
+	err := g.ParseBinary([]byte{})
 	if err != ErrEmptyInput {
 		t.Error("ErrEmptyInput not returned for empty input")
 	}
@@ -16,7 +17,7 @@ func TestNoInput(t *testing.T) {
 
 func TestUTF8(t *testing.T) { // issue #3
 	var g Grammar
-	if err := g.Parse([]byte(`°`)); err != nil {
+	if err := g.ParseUTF8([]byte(`°`)); err != nil {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
@@ -26,15 +27,27 @@ func TestUTF8(t *testing.T) { // issue #3
 	}
 }
 
-func TestPrint(t *testing.T) {
+func TestPrintUTF8(t *testing.T) {
 	var g Grammar
-	if err := g.Parse([]byte(testString)); err != nil {
+	if err := g.ParseUTF8([]byte(testString)); err != nil {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
 	g.Print(&buf)
 	if string(buf.Bytes()) != testString {
-		t.Error("Print() incorrect\nWanted:\n"+testString,
+		t.Error("UTF8 Print() incorrect\nWanted:\n"+testString,
 			"Got:\n", string(buf.Bytes()))
+	}
+}
+
+func TestPrintBinary(t *testing.T) {
+	var g Grammar
+	if err := g.ParseBinary(testBinary); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	g.Print(&buf)
+	if !reflect.DeepEqual(buf.Bytes(), testBinary) {
+		t.Error("Binary Print incorrect\nwanted:", testBinary, "\ngot:", buf.Bytes())
 	}
 }

--- a/sequitur_test.go
+++ b/sequitur_test.go
@@ -1,0 +1,13 @@
+package sequitur
+
+import (
+	"testing"
+)
+
+func TestNoInput(t *testing.T) {
+	g := new(Grammar)
+	err := g.Parse([]byte{})
+	if err != ErrEmptyInput {
+		t.Error("ErrEmptyInput not returned for empty input")
+	}
+}

--- a/sequitur_test.go
+++ b/sequitur_test.go
@@ -8,16 +8,15 @@ import (
 )
 
 func TestNoInput(t *testing.T) {
-	g := new(Grammar)
-	err := g.ParseBinary([]byte{})
+	_, err := ParseBinary([]byte{})
 	if err != ErrEmptyInput {
 		t.Error("ErrEmptyInput not returned for empty input")
 	}
 }
 
 func TestUTF8(t *testing.T) { // issue #3
-	var g Grammar
-	if err := g.ParseUTF8([]byte(`°`)); err != nil {
+	g, err := ParseUTF8([]byte(`°`))
+	if err != nil {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
@@ -28,8 +27,8 @@ func TestUTF8(t *testing.T) { // issue #3
 }
 
 func TestPrintUTF8(t *testing.T) {
-	var g Grammar
-	if err := g.ParseUTF8([]byte(testString)); err != nil {
+	g, err := ParseUTF8([]byte(testString))
+	if err != nil {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
@@ -41,8 +40,8 @@ func TestPrintUTF8(t *testing.T) {
 }
 
 func TestPrintBinary(t *testing.T) {
-	var g Grammar
-	if err := g.ParseBinary(testBinary); err != nil {
+	g, err := ParseBinary(testBinary)
+	if err != nil {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer

--- a/sequitur_test.go
+++ b/sequitur_test.go
@@ -1,7 +1,9 @@
 package sequitur
 
 import (
+	"bytes"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestNoInput(t *testing.T) {
@@ -9,5 +11,30 @@ func TestNoInput(t *testing.T) {
 	err := g.Parse([]byte{})
 	if err != ErrEmptyInput {
 		t.Error("ErrEmptyInput not returned for empty input")
+	}
+}
+
+func TestUTF8(t *testing.T) { // issue #3
+	var g Grammar
+	if err := g.Parse([]byte(`°`)); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	g.PrettyPrint(&buf)
+	if !utf8.Valid(buf.Bytes()) {
+		t.Error("invalid utf8: " + string(buf.Bytes()))
+	}
+}
+
+func TestPrint(t *testing.T) {
+	var g Grammar
+	if err := g.Parse([]byte(testString)); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	g.Print(&buf)
+	if string(buf.Bytes()) != testString {
+		t.Error("Print() incorrect\nWanted:\n"+testString,
+			"Got:\n", string(buf.Bytes()))
 	}
 }


### PR DESCRIPTION
Hi Damian, great work translating this algorithm into Go!

I saw this minor bug and had to fix it ;)

I'd like to investigate `go-sequitur` further, but need two things to be able to do that.

First, the repo needs a licence, so that potential users know on what basis they could re-use the code.

Second, there needs to be some way to view a parsed `Grammar` from outside the package, either by  making its types and their fields public, or, probably most usefully, by providing accessor functions.

...now updated with correct utf-8 handling (as per issue #3).