### PR TITLE
pretty-print unicode unambiguously

### DIFF
--- a/prettyprintbinary_test.go
+++ b/prettyprintbinary_test.go
@@ -9,7 +9,7 @@ var testBinary = []byte{0xfe, 0xff, 0xfd, 0xfe, 0xff, 1, 2, 3, 4, 5, 'a', 'b', 1
 
 func ExamplePrettyPrintBinary() {
 
-	g, err := ParseBinary(testBinary)
+	g, err := Parse(testBinary)
 	if err != nil {
 		panic(err)
 	}
@@ -23,7 +23,7 @@ func ExamplePrettyPrintBinary() {
 	fmt.Println(string(output.Bytes()))
 
 	// Output:
-	// 0 -> 1 0xFD 1 2 2
-	// 1 -> 0xFE 0xFF
-	// 2 -> 0x01 0x02 0x03 0x04 0x05 a b
+	// 0 -> 1 \xfd 1 2 2
+	// 1 -> \xfe \xff
+	// 2 -> \x01 \x02 \x03 \x04 \x05 a b
 }

--- a/prettyprintutf8_test.go
+++ b/prettyprintutf8_test.go
@@ -31,7 +31,7 @@ nine days old.
 
 func ExamplePrettyPrintUTF8() {
 
-	g, err := ParseUTF8([]byte(testString))
+	g, err := Parse([]byte(testString))
 	if err != nil {
 		panic(err)
 	}

--- a/sequitur_test.go
+++ b/sequitur_test.go
@@ -3,19 +3,20 @@ package sequitur
 import (
 	"bytes"
 	"reflect"
+	"strconv"
 	"testing"
 	"unicode/utf8"
 )
 
 func TestNoInput(t *testing.T) {
-	_, err := ParseBinary([]byte{})
+	_, err := Parse([]byte{})
 	if err != ErrEmptyInput {
 		t.Error("ErrEmptyInput not returned for empty input")
 	}
 }
 
 func TestUTF8(t *testing.T) { // issue #3
-	g, err := ParseUTF8([]byte(`°`))
+	g, err := Parse([]byte(`°`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +28,7 @@ func TestUTF8(t *testing.T) { // issue #3
 }
 
 func TestPrintUTF8(t *testing.T) {
-	g, err := ParseUTF8([]byte(testString))
+	g, err := Parse([]byte(testString))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func TestPrintUTF8(t *testing.T) {
 }
 
 func TestPrintBinary(t *testing.T) {
-	g, err := ParseBinary(testBinary)
+	g, err := Parse(testBinary)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,5 +49,69 @@ func TestPrintBinary(t *testing.T) {
 	g.Print(&buf)
 	if !reflect.DeepEqual(buf.Bytes(), testBinary) {
 		t.Error("Binary Print incorrect\nwanted:", testBinary, "\ngot:", buf.Bytes())
+	}
+}
+
+func TestRuneOrByteAppendBytesWithByte(t *testing.T) {
+	for i := 0; i <= 0xff; i++ {
+		rb := newByte(byte(i))
+		b := rb.appendBytes([]byte("ab"))
+		if want := []byte{'a', 'b', byte(i)}; !bytes.Equal(b, want) {
+			t.Errorf("unexpected bytes appended; got %q want %q", b, want)
+		}
+	}
+}
+
+func TestRuneOrByteAppendBytesWithRune(t *testing.T) {
+	buf := make([]byte, 10)
+	for i := 0; i <= utf8.MaxRune; i++ {
+		rb := newRune(rune(i))
+		buf := append(buf[:0], "ab"...)
+		buf = rb.appendBytes(buf)
+		if want := "ab" + string(i); string(buf) != want {
+			t.Errorf("unexpected bytes appended; got %q want %q", buf, want)
+		}
+	}
+}
+
+func TestRuneOrByteAppendEscapedWithByte(t *testing.T) {
+	buf := make([]byte, 10)
+	for i := 0; i <= 0xff; i++ {
+		if i == '"' || i == '\\' {
+			continue
+		}
+		buf = append(buf[:0], '"')
+		rb := newByte(byte(i))
+		buf = rb.appendEscaped(buf)
+		buf = append(buf, '"')
+		got, err := strconv.Unquote(string(buf))
+		if err != nil {
+			t.Errorf("cannot unquote %q (byte %x)", buf, i)
+			continue
+		}
+		if want := []byte{byte(i)}; !bytes.Equal([]byte(got), want) {
+			t.Errorf("unexpected result, got %q want %q ", got, want)
+		}
+	}
+}
+
+func TestRuneOrByteAppendEscapedWithRune(t *testing.T) {
+	buf := make([]byte, 20)
+	for i := 0; i <= utf8.MaxRune; i++ {
+		if i == '"' || i == '\\' {
+			continue
+		}
+		buf = append(buf[:0], '"')
+		rb := newRune(rune(i))
+		buf = rb.appendEscaped(buf)
+		buf = append(buf, '"')
+		got, err := strconv.Unquote(string(buf))
+		if err != nil {
+			t.Fatalf("cannot unquote %q (byte %x): %v", buf, i, err)
+			continue
+		}
+		if want := string(i); got != want {
+			t.Fatalf("unexpected result, got %q want %q ", got, want)
+		}
 	}
 }


### PR DESCRIPTION
As things are currently, if there's you see `0xff` (say) in the pretty-printed
grammar, it's ambiguous whether it means the byte 0xff or the rune 0xff
(represented by 0xc3 0xbf).

We change the output so that bytes and runes are unambiguously
represented using the same conventions used by Go's string quoting.

In doing so, it becomes clear that there's no real reason to distinguish
between bytes and UTF-8 input, because it's straightforward to
represent both internally. So we store input lexemes as the runeOrByte
type, and convert them appropriately on output, which removes
the need for the separate ParseUTF8 and ParseBinary functions
and the ErrMalformedUTF8 error.

Note: If we made it possible to have an empty grammar, then we
could parse all possible inputs and there would be no need
for an error return from Parse.